### PR TITLE
Descriptive texts and some other changes

### DIFF
--- a/observablehq.config.js
+++ b/observablehq.config.js
@@ -27,6 +27,11 @@ export default {
   </noscript>
   `,
   search: true,
+  pages: [
+    {name: "El indicador", path: "/imcv-dashboard"},
+    {name: "Cómo (y por qué) lo rehicimos", path: "/making-of"},
+    {name: "Los datos", path: "/data"},
+  ],
   header:`<style>
 
   #observablehq-header .logo {
@@ -68,8 +73,8 @@ export default {
         </a>
       </b>
       <span style="display: flex; align-items: baseline; gap: 0.5rem; font-size: 13px;">
-        <a target="_blank" href="https://github.com/fndvit/catalunya-en-dades">
-          <svg aria-roledescription="logo" aria-label="logo de GitHub" viewBox="0 0 64 64" width="48" height="48" class="svelte-1jqst0j"><path d="M32,16c-8.8,0-16,7.2-16,16c0,7.1,4.6,13.1,10.9,15.2 c0.8,0.1,1.1-0.3,1.1-0.8c0-0.4,0-1.4,0-2.7c-4.5,1-5.4-2.1-5.4-2.1c-0.7-1.8-1.8-2.3-1.8-2.3c-1.5-1,0.1-1,0.1-1 c1.6,0.1,2.5,1.6,2.5,1.6c1.4,2.4,3.7,1.7,4.7,1.3c0.1-1,0.6-1.7,1-2.1c-3.6-0.4-7.3-1.8-7.3-7.9c0-1.7,0.6-3.2,1.6-4.3 c-0.2-0.4-0.7-2,0.2-4.2c0,0,1.3-0.4,4.4,1.6c1.3-0.4,2.6-0.5,4-0.5c1.4,0,2.7,0.2,4,0.5c3.1-2.1,4.4-1.6,4.4-1.6 c0.9,2.2,0.3,3.8,0.2,4.2c1,1.1,1.6,2.5,1.6,4.3c0,6.1-3.7,7.5-7.3,7.9c0.6,0.5,1.1,1.5,1.1,3c0,2.1,0,3.9,0,4.4 c0,0.4,0.3,0.9,1.1,0.8C43.4,45.1,48,39.1,48,32C48,23.2,40.8,16,32,16z"></path></svg>
+        <a target="_blank" href="https://github.com/fndvit/ine-quality-life">
+          <svg aria-roledescription="logo" aria-label="logo de GitHub" viewBox="0 0 64 64" width="48" height="48"><path d="M32,16c-8.8,0-16,7.2-16,16c0,7.1,4.6,13.1,10.9,15.2 c0.8,0.1,1.1-0.3,1.1-0.8c0-0.4,0-1.4,0-2.7c-4.5,1-5.4-2.1-5.4-2.1c-0.7-1.8-1.8-2.3-1.8-2.3c-1.5-1,0.1-1,0.1-1 c1.6,0.1,2.5,1.6,2.5,1.6c1.4,2.4,3.7,1.7,4.7,1.3c0.1-1,0.6-1.7,1-2.1c-3.6-0.4-7.3-1.8-7.3-7.9c0-1.7,0.6-3.2,1.6-4.3 c-0.2-0.4-0.7-2,0.2-4.2c0,0,1.3-0.4,4.4,1.6c1.3-0.4,2.6-0.5,4-0.5c1.4,0,2.7,0.2,4,0.5c3.1-2.1,4.4-1.6,4.4-1.6 c0.9,2.2,0.3,3.8,0.2,4.2c1,1.1,1.6,2.5,1.6,4.3c0,6.1-3.7,7.5-7.3,7.9c0.6,0.5,1.1,1.5,1.1,3c0,2.1,0,3.9,0,4.4 c0,0.4,0.3,0.9,1.1,0.8C43.4,45.1,48,39.1,48,32C48,23.2,40.8,16,32,16z"></path></svg>
           <span>Colabora en el repositorio</span>
         </a>
       </span>

--- a/src/components/flowerChart.js
+++ b/src/components/flowerChart.js
@@ -35,6 +35,11 @@ export function flowerChart(data, selectedCCAA, year, y, cat, r) {
     .domain(d3.extent(data.map((d) => d[y]))) 
     .range([r / 3, r]); 
 
+  const yScaleSteam = d3
+    .scaleLinear()
+    .domain(d3.extent(data.map((d) => d[y]))) 
+    .range([0, r*2]); 
+
   // Define the arc
   const arc = d3
     .arc()
@@ -49,7 +54,7 @@ export function flowerChart(data, selectedCCAA, year, y, cat, r) {
     ) // Angle end
     .cornerRadius(r);
 
-  const baseY = r - yScale(indexValue) - 20;
+  const baseY = r - yScaleSteam(indexValue);
 
   const svg = d3
     .create("svg")

--- a/src/dashboard.css
+++ b/src/dashboard.css
@@ -70,6 +70,12 @@ li, label { font-weight: 500;}
 .card h3 { font-size: 1rem;}
 .card h4 { font-size: .85rem;}
 
+.header p {
+  padding-top: 1rem;
+  font-size: 1rem;
+  line-height: 1.75rem;
+}
+
 .sticky {
   position: sticky;
   top: 1rem;

--- a/src/dashboard.css
+++ b/src/dashboard.css
@@ -33,6 +33,10 @@
   --theme-foreground-focus: #f3f3f3; */
 }
 
+h1 {
+  font-size: 3.2rem;
+}
+
 h1, h2, h3, h4, h5, h6 {
   font-family: var(--sans-serif);
   font-weight: 600;
@@ -70,7 +74,7 @@ li, label { font-weight: 500;}
 .card h3 { font-size: 1rem;}
 .card h4 { font-size: .85rem;}
 
-.header p {
+p {
   padding-top: 1rem;
   font-size: 1rem;
   line-height: 1.75rem;
@@ -141,6 +145,7 @@ input[type='checkbox'] {
   font-size: .85rem;
   color: var(--dashboard-foreground-muted);
   width: 75%;
+  line-height: 1.25rem!important;
 }
 
 .legend {

--- a/src/data.md
+++ b/src/data.md
@@ -1,0 +1,6 @@
+---
+title: Los datos, en bruto
+toc: true
+---
+
+TK TK We need to made the tables available here. In different formats: wide and narrow.

--- a/src/data/consts.js
+++ b/src/data/consts.js
@@ -40,6 +40,26 @@ export const dimDict = ({
     dim8: "Entorno y medioambiente",
     dim9: "Experiencia general de la vida"
   });
+
+  export const yearTexts = ({
+    2008: "En 2008, Navarra, La Rioja y Asturias tienen los índices más elevados, todas superando ligeramente la media nacional. En el otro extremo, Ceuta, Galicia y Canarias se encuentran por debajo de la media, especialmente en Ocio y Condiciones materiales de vida.",
+    2009: "En 2009, Navarra y La Rioja continúan entre las regiones con mejores resultados, acompañadas por Aragón que sube al top 3. Galicia, Canarias y Ceuta siguen en los últimos lugares, sin cambios significativos en sus índices.",
+    2010: "Navarra, La Rioja y Aragón mantienen su liderazgo en 2010, con buenos resultados en Salud y Seguridad. Galicia sigue entre las regiones más rezagadas, acompañada de Ceuta y Andalucía, sin grandes mejoras en sus índices.",
+    2011: "En 2011, Navarra y Aragón vuelven a estar en el top junto a La Rioja, con buenos resultados en Gobernanza y Derechos básicos. Galicia y Ceuta se mantienen entre las regiones con los índices más bajos, mientras que Andalucía sigue mostrando resultados por debajo de la media.",
+    2012: "Navarra y Asturias encabezan el ranking en 2012, junto a La Rioja. En el lado contrario, Ceuta, Galicia y Canarias permanecen en los últimos lugares, afectadas principalmente por bajas en Condiciones materiales de vida.",
+    2013: "Navarra y La Rioja siguen con los índices más elevados en 2013, destacando en Seguridad y Entorno. Galicia y Ceuta continúan en la parte baja del ranking, sin avances significativos en Gobernanza y Vida social.",
+    2014: "La Rioja y Navarra vuelven a liderar en 2014, con buenos resultados en Ocio y Derechos básicos. Galicia sigue en los últimos lugares junto a Ceuta, afectada principalmente en Condiciones materiales y Seguridad física.",
+    2015: "En 2015, Navarra, La Rioja y Aragón mantienen los mejores resultados, destacando especialmente en Salud y Gobernanza. En cambio, Ceuta, Galicia y Canarias continúan en los últimos lugares, sin grandes mejoras en sus índices.",
+    2016: "En 2016, Navarra, La Rioja y País Vasco encabezan el ranking, con buenos resultados en Seguridad y Entorno. Ceuta, Galicia y Canarias permanecen entre los más rezagados, con índices bajos en Condiciones materiales de vida y Trabajo.",
+    2017: "Navarra y La Rioja mantienen su liderazgo en 2017, con buenos resultados en Educación y Seguridad. Ceuta mejora ligeramente pero sigue en la parte baja, acompañada por Galicia, ambas con dificultades en Ocio y Trabajo.",
+    2018: "Navarra y Aragón ocupan los primeros puestos en 2018, superando la media en Salud y Entorno. Andalucía cae al grupo de las últimas posiciones junto a Ceuta, con bajos índices en Trabajo y Condiciones materiales de vida.",
+    2019: "Navarra y La Rioja siguen liderando en 2019, destacando en Gobernanza y Seguridad. Ceuta y Andalucía permanecen en los últimos puestos, sin grandes avances en Educación y Vida social.",
+    2020: "Navarra y Aragón mantienen buenos resultados en 2020, con índices altos en Seguridad y Ocio. Ceuta y Andalucía continúan con los índices más bajos, afectadas principalmente en Trabajo y Experiencia de vida.",
+    2021: "Navarra y La Rioja continúan en el top en 2021, con mejoras en Gobernanza y Derechos básicos. Ceuta y Andalucía siguen ocupando los últimos lugares, sin mejoras importantes en Ocio y Trabajo.",
+    2022: "Navarra y La Rioja cierran 2022 con los índices más altos, mostrando estabilidad en Educación y Seguridad. Canarias, que no había figurado entre las últimas, aparece junto a Ceuta con los índices más bajos, afectadas principalmente en Trabajo y Entorno."
+  }  
+  )
+  
   
 export const dimList = [...new Set(data.map((d) => d.dim))].filter((dim) => dim.startsWith("dim"));
 

--- a/src/data/consts.js
+++ b/src/data/consts.js
@@ -41,25 +41,25 @@ export const dimDict = ({
     dim9: "Experiencia general de la vida"
   });
 
-  export const yearTexts = ({
-    2008: "En 2008, Navarra, La Rioja y Asturias tienen los índices más elevados, todas superando ligeramente la media nacional. En el otro extremo, Ceuta, Galicia y Canarias se encuentran por debajo de la media, especialmente en Ocio y Condiciones materiales de vida.",
-    2009: "En 2009, Navarra y La Rioja continúan entre las regiones con mejores resultados, acompañadas por Aragón que sube al top 3. Galicia, Canarias y Ceuta siguen en los últimos lugares, sin cambios significativos en sus índices.",
-    2010: "Navarra, La Rioja y Aragón mantienen su liderazgo en 2010, con buenos resultados en Salud y Seguridad. Galicia sigue entre las regiones más rezagadas, acompañada de Ceuta y Andalucía, sin grandes mejoras en sus índices.",
-    2011: "En 2011, Navarra y Aragón vuelven a estar en el top junto a La Rioja, con buenos resultados en Gobernanza y Derechos básicos. Galicia y Ceuta se mantienen entre las regiones con los índices más bajos, mientras que Andalucía sigue mostrando resultados por debajo de la media.",
-    2012: "Navarra y Asturias encabezan el ranking en 2012, junto a La Rioja. En el lado contrario, Ceuta, Galicia y Canarias permanecen en los últimos lugares, afectadas principalmente por bajas en Condiciones materiales de vida.",
-    2013: "Navarra y La Rioja siguen con los índices más elevados en 2013, destacando en Seguridad y Entorno. Galicia y Ceuta continúan en la parte baja del ranking, sin avances significativos en Gobernanza y Vida social.",
-    2014: "La Rioja y Navarra vuelven a liderar en 2014, con buenos resultados en Ocio y Derechos básicos. Galicia sigue en los últimos lugares junto a Ceuta, afectada principalmente en Condiciones materiales y Seguridad física.",
-    2015: "En 2015, Navarra, La Rioja y Aragón mantienen los mejores resultados, destacando especialmente en Salud y Gobernanza. En cambio, Ceuta, Galicia y Canarias continúan en los últimos lugares, sin grandes mejoras en sus índices.",
-    2016: "En 2016, Navarra, La Rioja y País Vasco encabezan el ranking, con buenos resultados en Seguridad y Entorno. Ceuta, Galicia y Canarias permanecen entre los más rezagados, con índices bajos en Condiciones materiales de vida y Trabajo.",
-    2017: "Navarra y La Rioja mantienen su liderazgo en 2017, con buenos resultados en Educación y Seguridad. Ceuta mejora ligeramente pero sigue en la parte baja, acompañada por Galicia, ambas con dificultades en Ocio y Trabajo.",
-    2018: "Navarra y Aragón ocupan los primeros puestos en 2018, superando la media en Salud y Entorno. Andalucía cae al grupo de las últimas posiciones junto a Ceuta, con bajos índices en Trabajo y Condiciones materiales de vida.",
-    2019: "Navarra y La Rioja siguen liderando en 2019, destacando en Gobernanza y Seguridad. Ceuta y Andalucía permanecen en los últimos puestos, sin grandes avances en Educación y Vida social.",
-    2020: "Navarra y Aragón mantienen buenos resultados en 2020, con índices altos en Seguridad y Ocio. Ceuta y Andalucía continúan con los índices más bajos, afectadas principalmente en Trabajo y Experiencia de vida.",
-    2021: "Navarra y La Rioja continúan en el top en 2021, con mejoras en Gobernanza y Derechos básicos. Ceuta y Andalucía siguen ocupando los últimos lugares, sin mejoras importantes en Ocio y Trabajo.",
-    2022: "Navarra y La Rioja cierran 2022 con los índices más altos, mostrando estabilidad en Educación y Seguridad. Canarias, que no había figurado entre las últimas, aparece junto a Ceuta con los índices más bajos, afectadas principalmente en Trabajo y Entorno."
-  }  
-  )
-  
+  export const yearTexts = (
+    {
+      2008:"En 2008, el año base del indicador, Navarra, La Rioja y Asturias lideran la tabla, mientras que Ceuta, Galicia y Canarias la cierran.",
+      2009:"En 2009, la calidad de vida en España descendió  respecto a 2008. Navarra y La Rioja continúan a la cabeza junto con Aragón, una de las que más mejora, en detrimento de Asturias. Galicia, una de las que más empeora, Canarias y Ceuta, una de las que más mejora, cierran la tabla. Murcia es de las que más caen.",
+      2010:"En 2010, la calidad de vida en España ascendió  respecto a 2009. Navarra, La Rioja y Aragón continúan a la cabeza. Galicia y Ceuta, una de las que más empeora, cierran la tabla junto con Andalucía. Canarias y Cataluña son de las que más mejoran, Melilla es de las que más caen.",
+      2011:"En 2011, la calidad de vida en España ascendió  respecto a 2010. Navarra, Aragón y La Rioja, una de las que más empeora, continúan a la cabeza. Galicia, Ceuta y Andalucía cierran la tabla. Melilla y Murcia son de las que más mejoran, País Vasco es de las que más caen.",
+      2012:"En 2012, la calidad de vida en España descendió ligeramente respecto a 2011. Navarra y La Rioja, una de las que más mejora, continúan a la cabeza junto con Asturias, otra de las que más mejora, en detrimento de Aragón. Ceuta, una de las que más empeora, y Galicia cierran la tabla junto con Canarias. Murcia es de las que más caen.",
+      2013:"En 2013, la calidad de vida en España descendió  respecto a 2012. Navarra, La Rioja, una de las que más mejora, y Asturias continúan a la cabeza. Ceuta, Galicia y Canarias cierran la tabla. Cataluña es de las que más mejoran, Melilla y Aragón son de las que más caen.",
+      2014:"En 2014, la calidad de vida en España ascendió ligeramente respecto a 2013. Navarra, La Rioja y Asturias, una de las que más mejora, continúan a la cabeza. Ceuta, Galicia, las dos que más empeoran, y Canarias cierran la tabla. Melilla es de las que más mejoran",
+      2015:"En 2015, la calidad de vida en España ascendió  respecto a 2014. Navarra y La Rioja continúan a la cabeza junto con Aragón, en detrimento de Asturias. Ceuta, una de las que más mejora, Galicia y Canarias cierran la tabla. Extremadura es de las que más mejoran, Melilla y Castilla-La Mancha son de las que más caen.",
+      2016:"En 2016, la calidad de vida en España ascendió  respecto a 2015. Navarra y La Rioja continúan a la cabeza junto con País Vasco, en detrimento de Aragón. Ceuta, Galicia y Canarias cierran la tabla. Baleares y Cataluña son de las que más mejoran, Melilla y Cantabria son de las que más caen.",
+      2017:"En 2017, la calidad de vida en España ascendió  respecto a 2016. Navarra y La Rioja continúan a la cabeza junto con Cantabria, una de las que más mejora, en detrimento de País Vasco. Galicia, Ceuta y Canarias cierran la tabla. Melilla es de las que más mejoran",
+      2018:"En 2018, la calidad de vida en España ascendió  respecto a 2017. Navarra, una de las que más empeora, y Cantabria continúan a la cabeza junto con Aragón, en detrimento de La Rioja. Ceuta y Galicia, una de las que más mejora, cierran la tabla junto con Andalucía. Extremadura es de las que más mejoran, País Vasco es de las que más caen.",
+      2019:"En 2019, la calidad de vida en España ascendió  respecto a 2018. Navarra, una de las que más mejora, y Aragón continúan a la cabeza junto con La Rioja, una de las que más mejora, en detrimento de Cantabria. Ceuta y Andalucía cierran la tabla junto con Murcia. Asturias y Baleares son de las que más caen.",
+      2020:"En 2020, la calidad de vida en España descendió  respecto a 2019. Navarra, Aragón y La Rioja continúan a la cabeza. Ceuta y Andalucía cierran la tabla junto con Canarias, una de las que más empeora. Baleares y Asturias son de las que más mejoran, Melilla es de las que más caen.",
+      2021:"En 2021, la calidad de vida en España descendió ligeramente respecto a 2020. Navarra, La Rioja y Aragón, una de las que más empeora, continúan a la cabeza. Ceuta, Andalucía y Canarias cierran la tabla. Extremadura y País Vasco son de las que más mejoran, Baleares es de las que más caen.",
+      2022:"En 2022, la calidad de vida en España descendió  respecto a 2021. Navarra, La Rioja y Aragón continúan a la cabeza. Ceuta, una de las que más empeora, Canarias y Andalucía, una de las que más mejora, cierran la tabla. País Vasco es de las que más mejoran, Baleares es de las que más caen."
+     }
+)
   
 export const dimList = [...new Set(data.map((d) => d.dim))].filter((dim) => dim.startsWith("dim"));
 

--- a/src/imcv-dashboard.md
+++ b/src/imcv-dashboard.md
@@ -23,16 +23,14 @@ const year = Generators.input(yearInput);
 
 const ccaaInput = filterLegend(ccaaList.filter(d => d !== "Total"), ccaaColors.filter(d =>  d !== "#797974"))
 const ccaa = Generators.input(ccaaInput);
-
 ```
 
-# TK TK Titular del Índice
-## TK TK subtítulo
+# La calidad de vida en España
 
 <div class="grid grid-charts">
   <div class="header">
-    <h2>¿Qué comunidades tienen un índice más elevado?</h2>
-    <p>${yearTexts[year]}</p>
+    <h2>¿Cuáles son las comunidades autónomas con mejor calidad de vida?</h2>
+    <p>${yearTexts[year]} A continuación puedes explorar los valores de las dimensiones para cada comunidad autónoma para el año seleccionado.</p>
   </div>
   <div class="menu sticky"> ${yearInput} </div>
   
@@ -61,7 +59,7 @@ const ccaa = Generators.input(ccaaInput);
 <div class="grid grid-charts">
   <div class="header">
     <h2>¿Cómo han evolucionado las dimensiones del índice?</h2>
-    <p>En estos gráficos puedes explorar la tendencia de cada comunidad autónoma y cada dimensión. La única dimensión que crece de manera relativamente consistente es <strong>Educación</strong>. Las más cambiantes son <strong>Trabajo —especialmente en momentos de crisis, Salud —muy variable de año en año, y Condiciones materiales de vida</strong>, <strong>Seguridad física y personal</strong> y <strong>Entorno y medioambiente</strong> con variaciones significativas entre años y entre comunidades autónomas. En contraste, <strong>Gobernanza y derechos básicos, Ocio y relaciones sociales</strong> y <strong>Experiencia general de la vida</strong>  se mantienen con fluctuaciones mínimas.</p>
+    <p>En estos gráficos puedes explorar la tendencia de cada comunidad autónoma y cada dimensión. La única dimensión que crece de manera relativamente consistente es Educación. Las más cambiantes son Trabajo —especialmente en momentos de crisis, Salud —muy variable de año en año, y Condiciones materiales de vida, Seguridad física y personal y Entorno y medioambiente con variaciones significativas entre años y entre comunidades autónomas. En contraste, Gobernanza y derechos básicos, Ocio y relaciones sociales< y Experiencia general de la vida se mantienen con fluctuaciones mínimas.</p>
   </div>
   
   <div class="sticky menu menu-tendencias">
@@ -88,12 +86,12 @@ const ccaa = Generators.input(ccaaInput);
 </div>
 
 <div class="grid grid-cols-4">
-  <h2 class="grid-colspan-4">TK TK Interactivo lorem ipsum título</h2>
-  <div class="sticky grid-colspan-1">Sliders</div>
+  <h2 class="grid-colspan-4">TK TK Customize the index</h2>
+  <div class="sticky grid-colspan-1">TK TK Sliders</div>
   <div class="card grid-colspan-3"></div>
 </div>
 
-<p class="notes">TK TK Justificación y links a los originales</p>
+<p class="notes">Este panel de datos reimagina la visualización del <a href="https://www.ine.es/experimental/imcv/experimental_ind_multi_calidad_vida.htm" target="_blank">Indicador Multidimensional de Calidad de Vida en España</a>, una estadística experimental del Instituto Nacional de Estadística, a partir de los datos abiertos disponibles en el INE.</p>
 
 <style>
   .grid-charts {

--- a/src/imcv-dashboard.md
+++ b/src/imcv-dashboard.md
@@ -5,7 +5,7 @@ style: ../dashboard.css
 ---
 
 ```js
-import {data as imcv, ccaaList, ccaaColors, dimList, dimDict} from "./data/consts.js";
+import {data as imcv, ccaaList, ccaaColors, dimList, dimDict, yearTexts} from "./data/consts.js";
 import {filterLegend} from "./components/filterLegend.js";
 import {flowerChart} from "./components/flowerChart.js";
 import {lineChart} from "./components/lineChart.js";
@@ -30,7 +30,10 @@ const ccaa = Generators.input(ccaaInput);
 ## TK TK subtítulo
 
 <div class="grid grid-charts">
-  <h2 class="header">TK TK Flores lorem ipsum título</h2> 
+  <div class="header">
+    <h2>¿Qué comunidades tienen un índice más elevado?</h2>
+    <p>${yearTexts[year]}</p>
+  </div>
   <div class="menu sticky"> ${yearInput} </div>
   
   <div class="card center chart"> 
@@ -56,7 +59,11 @@ const ccaa = Generators.input(ccaaInput);
 </div>
 
 <div class="grid grid-charts">
-  <h2 class="header">TK TK Tendencias lorem ipsum título</h2>
+  <div class="header">
+    <h2>¿Cómo han evolucionado las dimensiones del índice?</h2>
+    <p>En estos gráficos puedes explorar la tendencia de cada comunidad autónoma y cada dimensión. La única dimensión que crece de manera relativamente consistente es <strong>Educación</strong>. Las más cambiantes son <strong>Trabajo —especialmente en momentos de crisis, Salud —muy variable de año en año, y Condiciones materiales de vida</strong>, <strong>Seguridad física y personal</strong> y <strong>Entorno y medioambiente</strong> con variaciones significativas entre años y entre comunidades autónomas. En contraste, <strong>Gobernanza y derechos básicos, Ocio y relaciones sociales</strong> y <strong>Experiencia general de la vida</strong>  se mantienen con fluctuaciones mínimas.</p>
+  </div>
+  
   <div class="sticky menu menu-tendencias">
     ${ccaaInput}
     <p class="notes">Para asegurar la legibilidad de las gráficas, el filtro sólo te permite comparar hasta seis CC.AA. a la vez.</p>

--- a/src/index.md
+++ b/src/index.md
@@ -77,12 +77,12 @@ iframe {
 
 <div class="hero">
   <h1>Índice de Calidad de Vida (INE)</h1>
-  <h2>TK TK</h2>
+  <h2 style="max-width: 50%;">El IMCV es un indicador experimental desarrollado por el Instituto Nacional de Estadística de España (INE) construido a partir de 60 indicadores específicos agrupados en nueve dimensiones, que ofrece una visión general de la calidad de vida en España.
+</h2>
 </div>
 
 <!-- <iframe id="iframe" scrolling="no" src="https://sequera.fndvit.org/"></iframe> -->
 
-TK TK
 
 <div class="grid grid-cols-3">
   <div class="card">
@@ -92,7 +92,7 @@ TK TK
     <h2><a href="making-of"><em>Making-of</em> y otros enredos</a></h2>
   </div>
   <div class="card">
-    <h2><a href="">Los datos, en bruto</a></h2>
+    <h2><a href="data">Los datos, en bruto</a></h2>
   </div>
 </div>
 

--- a/src/making-of.md
+++ b/src/making-of.md
@@ -3,23 +3,21 @@ title: Making-of y otros enredos
 toc: true
 ---
 
-# Cómo rehicimos el Índice de Calidad de Vida de España por el INE
-El **[IMCV](https://ine.es/experimental/imcv/experimental_ind_multi_calidad_vida.htm)** es un [indicador experimental](https://ine.es/experimental/experimental.htm) desarrollado por el [Instituto Nacional de Estadística de España (INE)](https://ine.es/) construido a partir de 60 indicadores específicos agrupados en nueve dimensiones, que ofrece una visión general de la calidad de vida en España.
-
+# Cómo (y por qué) rehicimos el Indicador del INE
 Como viene siendo habitual cuando reimaginamos otras aplicaciones de datos públicos abiertos, el objetivo de este esfuerzo es celebrar los datos abiertos. Ya es emocionante que los datos existan, pero cuando se acompañan de una visualización que nos ayude a comprenderlos y explorarlos, ¡es aún más emocionante! Y, como siempre, hemos respetado el diseño original al tiempo que intentamos mejorar la claridad y la usabilidad del mismo.
 
 Y al igual que con nuestra iniciativa **[Catalunya en Dades](https://catalunya-en-dades.fndvit.org/)**, utilizamos [Observable, un generador de sitios estáticos gratuito y de código abierto](https://github.com/observablehq/framework) para aplicaciones de datos, en lugar de productos de software comerciales como _Tableau_ (la herramienta utilizada por el INE en este caso) o _Power BI_ (la herramienta utilizada por la administración catalana).
 
 ---
-## _Nos encantan_ las flores
-La visualización principal es un puñado de **flores multicolores**, una para cada comunidad autónoma. Dentro de cada flor, cada pétalo representa una de las nueve dimensiones del índice cuya longitud —y grosor— representa el valor de esa dimensión en la región.
+## **Nos chiflan** las flores
+La visualización principal es un puñado de **flores multicolores**, una para cada comunidad autónoma. En cada flor, cada pétalo representa una de las nueve dimensiones del índice y la longitud —y grosor— de cada pétalo representa el valor de esa dimensión en la región.
 
-Está basado en una visualización de 2013 del [Índice de Mejor Vida de la OCDE](https://www.oecdbetterlifeindex.org/), realizada por [Moritz Stefaner en colaboración con Raureif y Dominikus Baur](https://truth-and-beauty.net/projects/oecd-better-life-index). (Supongo que el concepto del índice en sí está igualmente inspirado en el índice de la OCDE).
+Está basado en una visualización de 2013 del [Índice de Mejor Vida de la OCDE](https://www.oecdbetterlifeindex.org/), realizada por [Moritz Stefaner en colaboración con Raureif y Dominikus Baur](https://truth-and-beauty.net/projects/oecd-better-life-index). (El concepto del índice en sí está igualmente inspirado en el [índice de la OCDE y otros proyectos similares](https://ine.es/experimental/imcv/exp_calidad_vida_multi.pdf)).
 
 No hemos _rediseñado_ la visualización de flor; solo la hemos limpiado, manteniendo los colores y la forma. Dado que estamos usando D3 en lugar de Tableau, lo que usó el INE originalmente, tenemos un control más preciso sobre la estética de las figuras.
 
 ---
-## También _nos encantan_ los mosaicos
+## También **nos chiflan** los mosaicos
 Hemos propuesto una visión general ligeramente diferente, con la parte superior dispuesta geográficamente en lugar de ordenada por valores como en el panel original. Hacemos eso porque hemos movido el segundo panel —en el que puedes manipular el peso de cada dimensión— a la parte inferior de la aplicación y ya puedes jugar con el orden allí.
 
 Los mapas en mosaico son un dispositivo visual fascinante y una [obsesión nuestra](https://github.com/fndvit/barfi).


### PR DESCRIPTION
This PR has a bunch of things, although it originally was only for the text 😅 

- I've added some **descriptive text** for the tile grid map. You can see what I did in the notebook. I only had to tweak a couple of things manually because I didn't want to overcomplicate the template. The text summarizes the overview and the changes for each year. They go like this:

  > "En 2022, la calidad de vida en España descendió respecto a 2021. Navarra, La Rioja y Aragón continúan a la cabeza. Ceuta, una de las que más empeora, Canarias y Andalucía, una de las que más mejora, cierran la tabla. País Vasco es de las que más mejoran, Baleares es de las que más caen."

- Exaggerated the steam length so the changes between regions were less subtle.
- Added some other texts here and there.

:closes #5 