### PR TITLE
feat: :sparkles: Add data explorer and download page

### DIFF
--- a/observablehq.config.js
+++ b/observablehq.config.js
@@ -30,7 +30,7 @@ export default {
   pages: [
     {name: "El indicador", path: "/imcv-dashboard"},
     {name: "Cómo (y por qué) lo rehicimos", path: "/making-of"},
-    {name: "Los datos", path: "/data"},
+    {name: "Descarga los datos", path: "/data"},
   ],
   header:`<style>
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "observable": "observable"
   },
   "dependencies": {
-    "@observablehq/framework": "^1.12.0",
+    "@observablehq/framework": "^1.11.0",
     "d3-dsv": "^3.0.1",
     "d3-time-format": "^4.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "observable": "observable"
   },
   "dependencies": {
-    "@observablehq/framework": "^1.11.0",
+    "@observablehq/framework": "^1.12.0",
     "d3-dsv": "^3.0.1",
     "d3-time-format": "^4.1.0"
   },

--- a/src/data.md
+++ b/src/data.md
@@ -3,4 +3,93 @@ title: Los datos, en bruto
 toc: true
 ---
 
-TK TK We need to made the tables available here. In different formats: wide and narrow.
+```js
+import {data as imcv, ccaaList, ccaaColors, ccaaNameDict, dimList, dimDict, yearTexts} from "./data/consts.js";
+
+const data = await FileAttachment("data/imcv.json").json();
+
+const filterInput = Inputs.form({
+  date: Inputs.select(d3.range(2008, 2023), {multiple: 4, value: d3.range(2008, 2023), label: "Selecciona los años", format: d=> d.toFixed(0)}),
+  ccaa: Inputs.select(ccaaList, {multiple: 4, value:ccaaList, label: "Selecciona las comunidades autónomas", format: d=> ccaaNameDict[d]}),
+  dim: Inputs.select([...dimList, "index"], {multiple: 4, value:[...dimList, "index"], label: "Selecciona las dimensiones", format: d=> dimDict[d]})
+});
+
+const filter = Generators.input(filterInput)
+
+```
+
+```js
+
+const dataView = imcv
+  .filter(d=> 
+    filter.date.includes(d.year)
+    && filter.ccaa.includes(d.ccaa)
+    && filter.dim.includes(d.dim)
+  )
+  .map((d) => ({
+    fecha: d.year.toFixed(0),
+    ccaa: ccaaNameDict[d.ccaa],
+    dim: dimDict[d.dim],
+    val: d.val
+  }))
+  
+
+const table = Inputs.table(
+  dataView,{
+    maxWidth: 1200,
+    select: false
+  }
+);
+
+const downloadJSON = (data) => {
+  const json = JSON.stringify(data, null, 2);
+  const blob = new Blob([json], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "datos-imcv.json";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+
+  URL.revokeObjectURL(url);
+}
+
+const downloadBtnJSON = Inputs.button("Descarga JSON", {
+  reduce: () => downloadJSON(dataView)});
+
+const downloadBtnCSV = Inputs.button("Descarga CSV", {
+  reduce: () => downloadJSON(imcv)});
+
+const downloadOriginal = Inputs.button("Descarga los datos originales", {reduce: () => window.location.href = "https://www.ine.es/experimental/imcv/datos_calidad_vida_multi.xlsx", })
+
+```
+
+# Descarga los datos
+
+En esta sección puedes **filtrar los datos** que visualizamos en el [panel](imcv-dashboard) por si quieres trabajar con ellos de manera independiente. Por defecto, todos los años, comunidades autónomas y dimensiones están seleccionadas.
+
+
+${filterInput}
+
+
+Estos son **los datos que has seleccionado**. La estructura de la tabla es *[apilada](https://en.wikipedia.org/wiki/Wide_and_narrow_data)*, ciertamente menos legible para los humanos, pero más práctica para trabajar programáticamente.
+
+<div class="grid">
+${table}
+</div>
+
+${downloadBtnJSON}
+
+---
+
+También puedes descargar todos los datos —incluso las estadísticas que componen cada dimensión— tal y como los proporciona el INE.
+
+${downloadOriginal}
+
+<style>
+  form {
+    margin-bottom: .5rem!important;
+  }
+</style>

--- a/src/data.md
+++ b/src/data.md
@@ -8,18 +8,36 @@ import {data as imcv, ccaaList, ccaaColors, ccaaNameDict, dimList, dimDict, year
 
 const data = await FileAttachment("data/imcv.json").json();
 
+const selectDate = Inputs.select(d3.range(2008, 2023), {multiple: 4, value: d3.range(2008, 2023), label: "Selecciona los años", format: d=> d.toFixed(0)});
+const selectCCAA = Inputs.select(ccaaList, {multiple: 4, value:ccaaList, label: "Selecciona las comunidades autónomas", format: d=> ccaaNameDict[d]});
+const selectDim = Inputs.select([...dimList, "index"], {multiple: 4, value:[...dimList, "index"], label: "Selecciona las dimensiones", format: d=> dimDict[d]});
+
+function set(input, value) {
+  input.value = value;
+  input.dispatchEvent(new Event("input", {bubbles: true}));
+}
+
+const resetFiltersButton = Inputs.button("Limipar filtros", 
+  { 
+    value: null, 
+    reduce: (value) => {
+      set(selectDate, d3.range(2008, 2023));
+      set(selectCCAA, ccaaList);             
+      set(selectDim, [...dimList, "index"]); 
+    } 
+  }
+);
+
 const filterInput = Inputs.form({
-  date: Inputs.select(d3.range(2008, 2023), {multiple: 4, value: d3.range(2008, 2023), label: "Selecciona los años", format: d=> d.toFixed(0)}),
-  ccaa: Inputs.select(ccaaList, {multiple: 4, value:ccaaList, label: "Selecciona las comunidades autónomas", format: d=> ccaaNameDict[d]}),
-  dim: Inputs.select([...dimList, "index"], {multiple: 4, value:[...dimList, "index"], label: "Selecciona las dimensiones", format: d=> dimDict[d]})
-});
+  date: selectDate,
+  ccaa: selectCCAA,
+  dim: selectDim,
+}); 
 
 const filter = Generators.input(filterInput)
-
 ```
 
 ```js
-
 const dataView = imcv
   .filter(d=> 
     filter.date.includes(d.year)
@@ -32,7 +50,6 @@ const dataView = imcv
     dim: dimDict[d.dim],
     val: d.val
   }))
-  
 
 const table = Inputs.table(
   dataView,{
@@ -40,7 +57,9 @@ const table = Inputs.table(
     select: false
   }
 );
+```
 
+```js
 const downloadJSON = (data) => {
   const json = JSON.stringify(data, null, 2);
   const blob = new Blob([json], { type: "application/json" });
@@ -59,9 +78,6 @@ const downloadJSON = (data) => {
 const downloadBtnJSON = Inputs.button("Descarga JSON", {
   reduce: () => downloadJSON(dataView)});
 
-const downloadBtnCSV = Inputs.button("Descarga CSV", {
-  reduce: () => downloadJSON(imcv)});
-
 const downloadOriginal = Inputs.button("Descarga los datos originales", {reduce: () => window.location.href = "https://www.ine.es/experimental/imcv/datos_calidad_vida_multi.xlsx", })
 
 ```
@@ -70,9 +86,8 @@ const downloadOriginal = Inputs.button("Descarga los datos originales", {reduce:
 
 En esta sección puedes **filtrar los datos** que visualizamos en el [panel](imcv-dashboard) por si quieres trabajar con ellos de manera independiente. Por defecto, todos los años, comunidades autónomas y dimensiones están seleccionadas.
 
-
 ${filterInput}
-
+${resetFiltersButton}
 
 Estos son **los datos que has seleccionado**. La estructura de la tabla es *[apilada](https://en.wikipedia.org/wiki/Wide_and_narrow_data)*, ciertamente menos legible para los humanos, pero más práctica para trabajar programáticamente.
 

--- a/src/data/consts.js
+++ b/src/data/consts.js
@@ -38,7 +38,8 @@ export const dimDict = ({
     dim6: "Seguridad física y personal",
     dim7: "Gobernanza y derechos básicos",
     dim8: "Entorno y medioambiente",
-    dim9: "Experiencia general de la vida"
+    dim9: "Experiencia general de la vida",
+    index: "Calidad de vida global"
   });
 
   export const yearTexts = (

--- a/src/index.md
+++ b/src/index.md
@@ -89,10 +89,10 @@ iframe {
     <h2><a href="imcv-dashboard">Panel del índice multidimensional de calidad de vida (IMCV)</a></h2>
   </div>
   <div class="card">
-    <h2><a href="making-of"><em>Making-of</em> y otros enredos</a></h2>
+    <h2><a href="making-of">Cómo (y por qué) lo rehicimos</a></h2>
   </div>
   <div class="card">
-    <h2><a href="data">Los datos, en bruto</a></h2>
+    <h2><a href="data">Descarga los datos</a></h2>
   </div>
 </div>
 


### PR DESCRIPTION
On the data download page; people can:
- Select the years, regions, and dimensions
- View the table
- Download the table with their selection
- Download the raw data table as in INE —direct link to them.

We could offer an additional option to change from narrow to wide view, but that only makes sense in certain data arrangements. For now, it's not worth us spending time on that feature.